### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ cp .env.local.example .env.local
 npm install
 ```
 
+Run these commands now and after any edits to `prisma/schema.prisma`: `npm run prismaDev` and `./node_modules/.bin/prisma generate`.
+
 # Start the application
 
 To run your site locally, use:

--- a/helpers/near.ts
+++ b/helpers/near.ts
@@ -1,0 +1,9 @@
+// https://docs.near.org/docs/concepts/account#account-id-rules / https://nomicon.io/DataStructures/Account
+// minimum length is 2, maximum length is 64, and then also enforce these rules:
+// TODO: Figure out the official validation rules for testnet and mainnet. See https://stackoverflow.com/q/72537015/470749
+export const testnetRegex = /^(\w|(?<!\.)\.)+(?<!\.)\.(testnet)$/;
+export const mainnetRegex = /^$|\.near$/; // Is empty or ends with .near. https://stackoverflow.com/a/3333525/470749
+
+// https://github.com/near/near-wallet/blob/40512df4d14366e1b8e05152fbf5a898812ebd2b/packages/frontend/src/utils/account.js#L8
+// https://github.com/near/near-wallet/blob/40512df4d14366e1b8e05152fbf5a898812ebd2b/packages/frontend/src/components/accounts/AccountFormAccountId.js#L95
+// https://github.com/near/near-cli/blob/cdc571b1625a26bcc39b3d8db68a2f82b91f06ea/commands/create-account.js#L75

--- a/helpers/profile.ts
+++ b/helpers/profile.ts
@@ -5,5 +5,5 @@ import { getLoggedInUser } from './user';
 
 export async function isProfileComplete(session: DefaultSession): Promise<boolean> {
   const user = await getLoggedInUser(session);
-  return Boolean(user.country) && Boolean(user.name) && Boolean(user.timeZone) && Boolean(user.softwareDevelopmentExperience); // ONEDAY: Check all of the required fields.
+  return Boolean(user.country) && Boolean(user.name) && Boolean(user.timeZone) && Boolean(user.softwareDevelopmentExperience) && Boolean(user.testnetAccount); // ONEDAY: Check all of the required fields.
 }

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -16,3 +16,11 @@ export type SerializableUser = Merge<
 export type ServerSidePropsRequest = IncomingMessage & {
   cookies: NextApiRequestCookies;
 };
+
+export type PropsWithOptionalName = {
+  // This is a modified version of GetInputPropsPayload from node_modules/@mantine/form/lib/types.d.ts
+  value: string;
+  onChange(event: any): void; // Why did Mantine not use React.ChangeEvent<HTMLInputElement>?
+  error?: React.ReactNode;
+  name?: string;
+};

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -20,6 +20,7 @@ export type ServerSidePropsRequest = IncomingMessage & {
 export type PropsWithOptionalName = {
   // This is a modified version of GetInputPropsPayload from node_modules/@mantine/form/lib/types.d.ts
   value: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onChange(event: any): void; // Why did Mantine not use React.ChangeEvent<HTMLInputElement>?
   error?: React.ReactNode;
   name?: string;

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -18,6 +18,7 @@ import { isProfileComplete } from '../helpers/profile';
 import { pluckFlash, setFlashVariable, withSessionSsr } from '../helpers/session';
 import { browserTimeZoneGuess } from '../helpers/time';
 import timeZones from '../helpers/timeZones';
+import { PropsWithOptionalName } from '../helpers/types';
 import { getLoggedInUser, getSerializableUser } from '../helpers/user';
 
 const schema = z.object({
@@ -101,9 +102,12 @@ export default function ProfilePage({ user, flash }: { user: User; flash: string
     },
   });
 
-  function getProps(fieldName: any) {
-    // ONEDAY: https://mantine.dev/form/use-form/#get-form-values-type
-    const props: any = form.getInputProps(fieldName);
+  type FormValues = typeof form.values; // https://mantine.dev/form/use-form/#get-form-values-type
+
+  type FieldName = keyof FormValues;
+
+  function getProps(fieldName: FieldName) {
+    const props: PropsWithOptionalName = form.getInputProps(fieldName);
     props.name = fieldName;
     return props;
   }

--- a/pages/styles.scss
+++ b/pages/styles.scss
@@ -53,9 +53,9 @@ div.mantine-RadioGroup-label,
   font-size: 0.9rem;
 }
 
-input[type='radio' i] {
-  margin-right: 0.3rem;
-}
+// input[type='radio' i] {
+//   margin-right: 0.3rem;
+// }
 
 .mantine-TextInput-root,
 .mantine-MultiSelect-root,


### PR DESCRIPTION
Initial validation of accounts 
The [nomicon spec](https://nomicon.io/DataStructures/Account) is not currently in practice and the suggested regex does not guard on some cases.
Based on previous research I played around and managed to come up with https://regex101.com/r/4DFD5t/2
As noted in the regex tester and the nomicon capital letters shall be considered invalid but we shall lowercase the input before storing it 

i have removed the `.min(2)` checks in the z.object schema because of:
-  they are covered by definition (since .testnet and .near are included in the char-count of the account they are always guaranteed to be above 2characters)
- in the case of `mainnetAccount` zod does not treat empty strings as special even if they are .optional() therefore .min(2) is still implied on empty strings '' (which is our initial value)

At a later point something like [node fetch](https://www.npmjs.com/package/node-fetch) can be utilized to make 
calls to the [NEAR RPC](https://docs.near.org/docs/api/rpc/contracts#view-account) to ensure the accounts actually do exist on the network
