### PR TITLE
updated regexes, fix validation

### DIFF
--- a/helpers/near.ts
+++ b/helpers/near.ts
@@ -1,8 +1,8 @@
 // https://docs.near.org/docs/concepts/account#account-id-rules / https://nomicon.io/DataStructures/Account
 // minimum length is 2, maximum length is 64, and then also enforce these rules:
 // TODO: Figure out the official validation rules for testnet and mainnet. See https://stackoverflow.com/q/72537015/470749
-export const testnetRegex = /^(\w|(?<!\.)\.)+(?<!\.)\.(testnet)$/;
-export const mainnetRegex = /^$|\.near$/; // Is empty or ends with .near. https://stackoverflow.com/a/3333525/470749
+export const testnetRegex = /^(([A-Za-z\d]+[\-_])*[A-Za-z\d]+\.)*testnet$/;
+export const mainnetRegex = /^(([A-Za-z\d]+[\-_])*[A-Za-z\d]+\.)*near$/;
 
 // https://github.com/near/near-wallet/blob/40512df4d14366e1b8e05152fbf5a898812ebd2b/packages/frontend/src/utils/account.js#L8
 // https://github.com/near/near-wallet/blob/40512df4d14366e1b8e05152fbf5a898812ebd2b/packages/frontend/src/components/accounts/AccountFormAccountId.js#L95

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -13,7 +13,7 @@ import LeadSource, { referralOptions, referralProgram } from '../components/Lead
 import ProgrammingLanguages from '../components/ProgrammingLanguages';
 import WhyJoin from '../components/WhyJoin';
 import countries from '../helpers/countries';
-import { mainnetRegex, testnetRegex } from '../helpers/near';
+import { testnetRegex, mainnetRegex } from '../helpers/near';
 import { chooseProgramPath, indexPath } from '../helpers/paths';
 import { isProfileComplete } from '../helpers/profile';
 import { pluckFlash, setFlashVariable, withSessionSsr } from '../helpers/session';
@@ -21,6 +21,7 @@ import { browserTimeZoneGuess } from '../helpers/time';
 import timeZones from '../helpers/timeZones';
 import { PropsWithOptionalName } from '../helpers/types';
 import { getLoggedInUser, getSerializableUser } from '../helpers/user';
+import { InferGetServerSidePropsType } from "next";
 
 /* ONEDAY: Figure out how to enable "eager validation" upon any form submission that has invalid entries.
  In other words, after first form submission failure, perhaps every field should revalidate on every keyUp event. */
@@ -29,18 +30,17 @@ const schema = z.object({
   name: z.string().min(2, { message: 'Your name must have at least 2 letters.' }),
   testnetAccount: z
     .string()
-    .min(2, { message: 'Minimum 2 characters' })
-    .max(64, { message: 'Maxium 64 characters' })
+    .max(64, { message: 'Maximum 64 characters' })
     // TODO: Figure out the official validation rules. See https://stackoverflow.com/q/72537015/470749
     .regex(testnetRegex, { message: 'Please provide a valid NEAR testnet account address. Usually testnet accounts end with `.testnet`. See _____ for details.' }),
   mainnetAccount: z
     .string()
-    .min(2, { message: 'Minimum 2 characters' })
-    .max(64, { message: 'Maxium 64 characters' })
-    // TODO: Figure out the official validation rules. See https://stackoverflow.com/q/72537015/470749
-    .regex(mainnetRegex, {
+    .max(64, { message: 'Maximum 64 characters' })
+    .refine(acc =>
+      acc === '' || mainnetRegex.test(acc), {
       message: 'Please provide a valid NEAR mainnet account address. Usually mainnet accounts end with `.near`. See _____ for details.',
-    }),
+    })
+    .optional(),
 });
 
 const softwareDevelopmentExperienceOptions = ['I am not a software developer', 'less than 1 year', '1 - 2 years', '2 - 5 years', '5 - 10 years', 'more than 10 years'];
@@ -78,7 +78,7 @@ export const getServerSideProps = withSessionSsr(async ({ req }) => {
 });
 
 // eslint-disable-next-line max-lines-per-function
-export default function ProfilePage({ user, flash }: { user: User; flash: string }) {
+export default function ProfilePage({ user, flash }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [userState, setUserState] = useState<User>(user);
   const formRef = useRef<HTMLFormElement>(null);
 


### PR DESCRIPTION
Initial validation of accounts 
The [nomicon spec](https://nomicon.io/DataStructures/Account) is not currently in practice and the suggested regex does not guard on some cases.
Based on previous research I played around and managed to come up with https://regex101.com/r/4DFD5t/2
As noted in the regex tester and the nomicon capital letters shall be considered invalid but we shall lowercase the input before storing it 

i have removed the `.min(2)` checks in the z.object schema because of:
-  they are covered by definition (since .testnet and .near are included in the char count of the account they are always guaranteed to be above 2characters)
- in the case of `mainnetAccount` zod does not treat empty strings as special even if they are .optional() therefore .min(2) is still implied (required) on empty strings '' (which is our initial value)

At a later point something like [node fetch](https://www.npmjs.com/package/node-fetch) can be utilized to make 
calls to the [NEAR RPC](https://docs.near.org/docs/api/rpc/contracts#view-account) to ensure the accounts actually do exist on the network